### PR TITLE
feat: Add Dark Mode and Custom Welcome Message

### DIFF
--- a/options.html
+++ b/options.html
@@ -25,6 +25,16 @@
         <label for="gemini-key">Gemini API Key:</label>
         <input type="password" id="gemini-key" name="gemini-key">
       </div>
+
+      <hr style="margin: 20px 0;">
+
+      <div class="form-group">
+        <label for="dark-mode-toggle" style="display: inline-block; margin-right: 10px; vertical-align: middle;">Dark Mode:</label>
+        <input type="checkbox" id="dark-mode-toggle" name="dark-mode-toggle" style="vertical-align: middle;">
+      </div>
+
+      <hr style="margin: 20px 0;">
+
       <button type="submit" id="save-button">Save Settings</button>
     </form>
     <div id="status-message">

--- a/options.js
+++ b/options.js
@@ -1,16 +1,27 @@
+// Ensure DOM elements are queried after DOMContentLoaded
+let darkModeToggle;
+
+function applyDarkModePreference(isDarkMode) {
+    if (isDarkMode) {
+        document.body.classList.add('dark-mode');
+    } else {
+        document.body.classList.remove('dark-mode');
+    }
+}
+
 function saveOptions(e) {
     e.preventDefault();
     const confluenceUrl = document.getElementById('confluence-url').value;
     const confluenceUsername = document.getElementById('confluence-username').value;
     const confluenceToken = document.getElementById('confluence-token').value;
     const geminiKey = document.getElementById('gemini-key').value;
+    const isDarkMode = darkModeToggle.checked; // Get dark mode state
 
     const status = document.getElementById('status-message');
     status.textContent = ''; // Clear previous messages
     status.classList.remove('success-style', 'error-style');
 
-
-    // Basic validation
+    // Basic validation for API keys
     if (!confluenceUrl || !geminiKey) {
         status.textContent = 'Error: Confluence URL and Gemini API Key are required.';
         status.classList.add('error-style');
@@ -25,7 +36,8 @@ function saveOptions(e) {
         confluenceUrl: confluenceUrl,
         confluenceUsername: confluenceUsername,
         confluenceToken: confluenceToken,
-        geminiKey: geminiKey
+        geminiKey: geminiKey,
+        darkMode: isDarkMode // Save dark mode preference
     }, () => {
         if (chrome.runtime.lastError) {
             console.error("Error saving settings:", chrome.runtime.lastError);
@@ -34,6 +46,8 @@ function saveOptions(e) {
         } else {
             status.textContent = 'Settings saved successfully!';
             status.classList.add('success-style');
+            // Apply dark mode immediately after saving, if changed
+            applyDarkModePreference(isDarkMode);
         }
         setTimeout(() => {
             status.textContent = '';
@@ -43,23 +57,51 @@ function saveOptions(e) {
 }
 
 function loadOptions() {
-    chrome.storage.local.get(['confluenceUrl', 'confluenceUsername', 'confluenceToken', 'geminiKey'], (items) => {
-        const status = document.getElementById('status-message');
-        status.textContent = ''; // Clear previous messages
-        status.classList.remove('success-style', 'error-style');
+    // Get references to all settings fields, including the new dark mode toggle
+    const confluenceUrlInput = document.getElementById('confluence-url');
+    const confluenceUsernameInput = document.getElementById('confluence-username');
+    const confluenceTokenInput = document.getElementById('confluence-token');
+    const geminiKeyInput = document.getElementById('gemini-key');
+    // darkModeToggle is already globally available after DOMContentLoaded
 
+    const status = document.getElementById('status-message');
+    status.textContent = '';
+    status.classList.remove('success-style', 'error-style');
+
+    chrome.storage.local.get(['confluenceUrl', 'confluenceUsername', 'confluenceToken', 'geminiKey', 'darkMode'], (items) => {
         if (chrome.runtime.lastError) {
             console.error("Error loading settings:", chrome.runtime.lastError);
             status.textContent = 'Error loading settings: ' + chrome.runtime.lastError.message;
             status.classList.add('error-style');
             return;
         }
-        document.getElementById('confluence-url').value = items.confluenceUrl || '';
-        document.getElementById('confluence-username').value = items.confluenceUsername || '';
-        document.getElementById('confluence-token').value = items.confluenceToken || '';
-        document.getElementById('gemini-key').value = items.geminiKey || '';
+
+        confluenceUrlInput.value = items.confluenceUrl || '';
+        confluenceUsernameInput.value = items.confluenceUsername || '';
+        confluenceTokenInput.value = items.confluenceToken || '';
+        geminiKeyInput.value = items.geminiKey || '';
+
+        const isDarkMode = !!items.darkMode;
+        darkModeToggle.checked = isDarkMode;
+        applyDarkModePreference(isDarkMode);
     });
 }
 
-document.addEventListener('DOMContentLoaded', loadOptions);
-document.getElementById('settings-form').addEventListener('submit', saveOptions);
+document.addEventListener('DOMContentLoaded', () => {
+    // Initialize darkModeToggle after DOM is loaded
+    darkModeToggle = document.getElementById('dark-mode-toggle');
+
+    loadOptions(); // Load all options, including dark mode state
+
+    document.getElementById('settings-form').addEventListener('submit', saveOptions);
+
+    if(darkModeToggle) { // Ensure toggle exists before adding listener
+        darkModeToggle.addEventListener('change', () => {
+            const isDarkMode = darkModeToggle.checked;
+            applyDarkModePreference(isDarkMode);
+            // Note: The preference is saved when the main "Save Settings" button is clicked.
+            // If immediate save on toggle change is desired, that's a separate small change.
+            // For now, it changes visually and is saved with other settings.
+        });
+    }
+});

--- a/popup.js
+++ b/popup.js
@@ -5,6 +5,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const loadingIndicator = document.getElementById('loading-indicator');
     const errorMessage = document.getElementById('error-message');
 
+    // Apply Dark Mode theme based on preference
+    chrome.storage.local.get(['darkMode'], (items) => {
+        if (chrome.runtime.lastError) {
+            console.error("Error loading dark mode setting:", chrome.runtime.lastError.message);
+            // Default to light mode or do nothing, letting CSS defaults apply
+            return;
+        }
+        const isDarkMode = !!items.darkMode;
+        if (isDarkMode) {
+            document.body.classList.add('dark-mode');
+        } else {
+            document.body.classList.remove('dark-mode'); // Ensure it's removed if not set or false
+        }
+    });
+
     function addMessageToChat(text, sender, sourceUrls = []) {
         const messageDiv = document.createElement('div');
         messageDiv.classList.add('message', sender === 'user' ? 'user-message' : 'conrad-message');
@@ -97,22 +112,29 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initial check for settings and set focus
     chrome.storage.local.get(['confluenceUrl', 'geminiKey'], (items) => {
         if (!items.confluenceUrl || !items.geminiKey) {
-            if (chatMessages.children.length === 0) {
-                errorMessage.textContent = 'Welcome! Please configure Confluence URL and Gemini API Key in Settings to get started.';
-                errorMessage.classList.remove('error-style');
+            if (chatMessages.children.length === 0) { // Only show if chat is empty
+                errorMessage.textContent = "¡Hola! Soy Conrad, tu asistente virtual para la biblioteca de Confluence. ¿En qué te puedo ayudar hoy?";
+                errorMessage.classList.remove('error-style'); // Ensure neutral styling
+                // Clearing direct styles just in case, though class removal should be enough
+                errorMessage.style.color = '';
+                errorMessage.style.backgroundColor = '';
                 errorMessage.style.display = 'block';
             }
         } else {
+            // Optional: If settings ARE found and chat is empty, one could add a different welcome message
+            // For now, we only show a special message if settings are MISSING.
             if (chatMessages.children.length === 0) {
-                // Optional welcome message
+                 // Example: addMessageToChat("Conrad is ready. Ask me anything!", "conrad");
             }
         }
     });
 
     messageInput.focus(); // Set initial focus
 
+    // Clear welcome/config message if user starts typing
     messageInput.addEventListener('input', () => {
-        if (errorMessage.textContent.startsWith('Welcome!') || errorMessage.textContent.startsWith('Configuration missing')) {
+        const currentMessage = errorMessage.textContent;
+        if (currentMessage.startsWith('¡Hola! Soy Conrad') || currentMessage.startsWith('Configuration missing')) {
             errorMessage.style.display = 'none';
             errorMessage.textContent = '';
         }

--- a/style.css
+++ b/style.css
@@ -1,19 +1,95 @@
 /* General Reset / Base */
+:root {
+  /* Light Theme (Default) */
+  --body-bg-popup: #f0f0f0;
+  --body-bg-options: #f8f9fa;
+  --container-bg: #ffffff;
+  --text-primary: #212529;
+  --text-secondary: #495057;
+  --text-muted: #6c757d;
+  --border-color: #ced4da;
+  --border-color-strong: #adb5bd;
+  --link-color: #007bff;
+  --link-hover-color: #0056b3;
+  --button-primary-bg: #007bff;
+  --button-primary-text: #ffffff;
+  --button-secondary-bg: #28a745;
+  --button-secondary-text: #ffffff;
+  --button-disabled-bg: #6c757d;
+  --button-disabled-text: #ffffff;
+  --message-user-bg: #007bff;
+  --message-user-text: #ffffff;
+  --message-conrad-bg: #e9ecef;
+  --message-conrad-text: #212529;
+  --input-bg: #ffffff;
+  --input-area-bg: #f8f9fa; /* Popup input area */
+  --input-focus-border: #80bdff;
+  --input-focus-shadow: rgba(0,123,255,.25);
+  --status-success-bg: #d4edda;
+  --status-success-text: #155724;
+  --status-success-border: #c3e6cb;
+  --status-error-bg: #f8d7da;
+  --status-error-text: #721c24;
+  --status-error-border: #f5c6cb;
+  --shadow-color: rgba(0,0,0,0.05);
+  --hr-color: #e0e0e0;
+
+  /* Font */
+  --font-family: Arial, Helvetica, sans-serif;
+  --base-font-size: 14px;
+}
+
+body.dark-mode {
+  --body-bg-popup: #1e1e1e; /* Darker background for popup */
+  --body-bg-options: #121212; /* Darkest for options page */
+  --container-bg: #2c2c2c; /* Dark containers */
+  --text-primary: #e0e0e0;
+  --text-secondary: #b0b0b0;
+  --text-muted: #888888;
+  --border-color: #444444;
+  --border-color-strong: #555555;
+  --link-color: #80bfff;
+  --link-hover-color: #a0cfff;
+  --button-primary-bg: #007bff; /* Keeping blue for now, ensure contrast */
+  --button-primary-text: #ffffff;
+  --button-secondary-bg: #28a745; /* Keeping green for now */
+  --button-secondary-text: #ffffff;
+  --button-disabled-bg: #555555;
+  --button-disabled-text: #ababab;
+  --message-user-bg: #0056b3; /* Darker blue */
+  --message-user-text: #e0e0e0;
+  --message-conrad-bg: #383838;
+  --message-conrad-text: #e0e0e0;
+  --input-bg: #3a3a3a;
+  --input-area-bg: #2c2c2c; /* Popup input area */
+  --input-focus-border: #80bfff; /* Lighter blue for focus */
+  --input-focus-shadow: rgba(128,191,255,.25);
+  --status-success-bg: #2a5c33;
+  --status-success-text: #d4edda;
+  --status-success-border: #306838;
+  --status-error-bg: #6b2128;
+  --status-error-text: #f8d7da;
+  --status-error-border: #7c2930;
+  --shadow-color: rgba(255,255,255,0.03);
+  --hr-color: #444444;
+}
+
 html {
-  font-family: Arial, Helvetica, sans-serif; /* More specific sans-serif */
-  font-size: 14px; /* Base font size for the extension */
+  font-family: var(--font-family);
+  font-size: var(--base-font-size);
 }
 
 /* Styles specific to the popup window */
 body.popup-body {
   width: 380px;
   height: 520px;
-  overflow: hidden; /* Prevent scrollbars on body itself for fixed size popup */
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  margin:0; /* Ensure no default body margin */
-  padding:0; /* Ensure no default body padding */
-  background-color: #f0f0f0; /* Light grey background for the whole popup */
+  margin:0;
+  padding:0;
+  background-color: var(--body-bg-popup);
+  color: var(--text-primary);
 }
 
 /* Styles specific to the options page */
@@ -21,19 +97,19 @@ body.options-page {
   width: auto;
   height: auto;
   overflow: auto;
-  margin:0; /* Ensure no default body margin */
-  padding:20px; /* Add some padding to the options page body */
-  background-color: #f8f9fa; /* Light background for options page */
+  margin:0;
+  padding:20px;
+  background-color: var(--body-bg-options);
+  color: var(--text-primary);
 }
-
 
 /* Chat Popup Specific Styles */
 #chat-container {
   display: flex;
   flex-direction: column;
-  flex-grow: 1; /* Allow chat container to fill popup body */
+  flex-grow: 1;
   padding: 10px;
-  box-sizing: border-box; /* Include padding in height calculation */
+  box-sizing: border-box;
 }
 
 #settings-link {
@@ -43,12 +119,13 @@ body.options-page {
 }
 
 #settings-link a {
-  color: #007bff;
+  color: var(--link-color);
   text-decoration: none;
 }
 #settings-link a:hover, #settings-link a:focus {
   text-decoration: underline;
-  outline: 1px dotted #007bff; /* Focus indicator */
+  color: var(--link-hover-color);
+  outline: 1px dotted var(--link-color);
 }
 
 #chat-messages {
@@ -56,34 +133,33 @@ body.options-page {
   overflow-y: auto;
   margin-bottom: 8px;
   padding: 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color-strong);
   border-radius: 4px;
-  background-color: #ffffff;
+  background-color: var(--container-bg);
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-/* Individual message styling */
 .message {
   padding: 10px 14px;
   border-radius: 18px;
   max-width: 85%;
   word-wrap: break-word;
   line-height: 1.45;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  box-shadow: 0 1px 2px var(--shadow-color);
 }
 
 .user-message {
-  background-color: #007bff;
-  color: white;
+  background-color: var(--message-user-bg);
+  color: var(--message-user-text);
   align-self: flex-end;
   border-bottom-right-radius: 6px;
 }
 
 .conrad-message {
-  background-color: #e9ecef;
-  color: #212529;
+  background-color: var(--message-conrad-bg);
+  color: var(--message-conrad-text);
   align-self: flex-start;
   border-bottom-left-radius: 6px;
 }
@@ -92,106 +168,108 @@ body.options-page {
   margin-top: 8px;
   font-size: 0.85em;
   padding-top: 5px;
-  border-top: 1px solid rgba(0,0,0,0.05);
+  border-top: 1px solid var(--shadow-color); /* Use shadow or a light border */
 }
-.user-message .source-urls {
-    border-top: 1px solid rgba(255,255,255,0.2);
-}
+/* Ensure contrast for user message sources if ever used */
+.user-message .source-urls { border-top: 1px solid rgba(255,255,255,0.2); }
+.conrad-message .source-urls { border-top: 1px solid var(--border-color); }
+
+
 .message .source-urls a {
-  color: #0056b3;
+  color: var(--link-color);
   text-decoration: none;
   margin-right: 12px;
   display: inline-block;
   padding: 2px 0;
 }
 .message .source-urls a:hover, .message .source-urls a:focus {
-  color: #003d80;
+  color: var(--link-hover-color);
   text-decoration: underline;
-  outline: 1px dotted #0056b3; /* Focus indicator */
+  outline: 1px dotted var(--link-color);
 }
-
 
 #loading-indicator {
   text-align: center;
   padding: 10px;
-  color: #555;
+  color: var(--text-muted);
   font-style: italic;
-  display: none; /* Managed by JS */
+  display: none;
 }
 
-#error-message {
+#error-message { /* Used for chat errors and initial welcome message */
   text-align: center;
   padding: 10px;
   margin-bottom: 8px;
   border-radius: 4px;
-  display: none; /* Managed by JS */
+  color: var(--text-primary); /* Default color, overridden by .error-style */
+  background-color: transparent; /* Default background */
+  display: none;
 }
-
 
 #input-area {
   display: flex;
   align-items: center;
   padding: 10px;
-  border-top: 1px solid #ccc;
-  background-color: #f8f9fa;
+  border-top: 1px solid var(--border-color-strong);
+  background-color: var(--input-area-bg);
 }
 
 #message-input {
   flex-grow: 1;
   padding: 10px 15px;
-  border: 1px solid #ced4da;
+  border: 1px solid var(--border-color);
   border-radius: 20px;
   margin-right: 8px;
   font-size: 1em;
-  background-color: #fff;
+  background-color: var(--input-bg);
+  color: var(--text-primary);
 }
 #message-input:focus {
-  border-color: #80bdff;
+  border-color: var(--input-focus-border);
   outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+  box-shadow: 0 0 0 0.2rem var(--input-focus-shadow);
 }
-
 
 #send-button {
   padding: 10px 18px;
-  background-color: #007bff;
-  color: white;
+  background-color: var(--button-primary-bg);
+  color: var(--button-primary-text);
   border: none;
   border-radius: 20px;
   cursor: pointer;
   font-size: 1em;
   transition: background-color 0.15s ease-in-out;
 }
-
 #send-button:hover, #send-button:focus {
-  background-color: #0056b3;
-  outline: 1px solid #003d80; /* Focus outline */
+  background-color: var(--link-hover-color); /* Using link hover as it's often a darker shade of primary */
+  outline: 1px dotted var(--button-primary-bg);
 }
 #send-button:disabled {
-  background-color: #6c757d;
+  background-color: var(--button-disabled-bg);
+  color: var(--button-disabled-text);
   cursor: not-allowed;
 }
-
 
 /* Options Page Specific Styles */
 #options-container {
   padding: 25px;
   max-width: 600px;
-  margin: 0 auto; /* Centering for options page content */
-  background-color: #ffffff;
-  border: 1px solid #dee2e6;
+  margin: 0 auto;
+  background-color: var(--container-bg);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.075);
+  box-shadow: 0 2px 10px var(--shadow-color);
 }
 
 #options-container h1 {
   font-size: 1.8em;
   margin-bottom: 25px;
-  color: #343a40;
+  color: var(--text-primary);
   text-align: center;
 }
 
-#settings-form div {
+#settings-form div.form-group, /* Target specific divs if needed */
+#settings-form div { /* Keep general for other divs */
   margin-bottom: 18px;
 }
 
@@ -199,41 +277,53 @@ body.options-page {
   display: block;
   margin-bottom: 6px;
   font-weight: 600;
-  color: #495057;
+  color: var(--text-secondary);
 }
 
 #settings-form input[type="text"],
-#settings-form input[type="password"] {
+#settings-form input[type="password"],
+#settings-form input[type="checkbox"] { /* Added checkbox for consistency if styled later */
   width: calc(100% - 22px);
   padding: 10px;
-  border: 1px solid #ced4da;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 1em;
-  background-color: #fff;
+  background-color: var(--input-bg);
+  color: var(--text-primary);
   transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }
-#settings-form input[type="text"]:focus,
-#settings-form input[type="password"]:focus {
-  border-color: #80bdff;
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+#settings-form input[type="checkbox"] { /* Specific styling for checkbox */
+    width: auto; /* Override width */
+    padding: initial; /* Override padding */
+    margin-right: 5px;
+    vertical-align: middle;
 }
 
+#settings-form input[type="text"]:focus,
+#settings-form input[type="password"]:focus {
+  border-color: var(--input-focus-border);
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem var(--input-focus-shadow);
+}
 
 #settings-form button {
   padding: 12px 22px;
-  background-color: #28a745;
-  color: white;
+  background-color: var(--button-secondary-bg);
+  color: var(--button-secondary-text);
   border: none;
   border-radius: 4px;
   cursor: pointer;
   font-size: 1.05em;
   transition: background-color 0.15s ease-in-out;
 }
-
 #settings-form button:hover, #settings-form button:focus {
-  background-color: #218838;
-  outline: 2px solid #1e7e34; /* Focus indicator */
+  background-color: var(--link-hover-color); /* Assuming secondary button can use primary link hover */
+  outline: 2px solid var(--button-secondary-bg);
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--hr-color);
 }
 
 /* Status messages (shared styles) */
@@ -247,29 +337,34 @@ body.options-page {
   text-align: center;
 }
 
-/* Specific error message style for popup, if #error-message needs it */
-#error-message.error-style { /* If JS adds this class */
-  background-color: #f8d7da;
-  color: #721c24;
-  border-color: #f5c6cb;
-}
-
-
-/* General error message style - used by options.js and potentially popup.js */
-.error-style {
-  background-color: #f8d7da;
-  color: #721c24;
-  border-color: #f5c6cb;
+/* Specific error message style for popup (and options) */
+#error-message.error-style, /* For popup */
+#status-message.error-style /* For options, if JS adds this class */ {
+  background-color: var(--status-error-bg);
+  color: var(--status-error-text);
+  border-color: var(--status-error-border);
 }
 
 /* General success message style - used by options.js */
-.success-style {
-  background-color: #d4edda;
-  color: #155724;
-  border-color: #c3e6cb;
+#status-message.success-style {
+  background-color: var(--status-success-bg);
+  color: var(--status-success-text);
+  border-color: var(--status-success-border);
 }
 
-/* Default status message from options.js - ensure it doesn't conflict */
-#status-message { /* This ID is specific to options.html */
-  margin-top:15px;
+/* Ensure the initial welcome/setup message in popup's #error-message is neutral */
+#error-message:not(.error-style) {
+    color: var(--text-muted); /* Use muted text color for neutral messages */
+    background-color: transparent; /* No specific background */
+}
+/* Dark mode toggle styling (basic) */
+.form-group label[for="dark-mode-toggle"] { /* Ensure label is styled */
+    color: var(--text-secondary);
+}
+#dark-mode-toggle {
+    accent-color: var(--link-color); /* Makes the checkbox theme-aware */
+}
+#dark-mode-toggle:focus {
+    outline: 1px dotted var(--link-color);
+    box-shadow: 0 0 0 0.1rem var(--input-focus-shadow);
 }


### PR DESCRIPTION
This commit introduces two new user-facing features:

1.  **Custom Welcome Message:**
    - The initial message displayed in the popup (when settings are not yet configured) is now in Spanish: "¡Hola! Soy Conrad, tu asistente virtual para la biblioteca de Confluence. ¿En qué te puedo ayudar hoy?"
    - This message is cleared when you start typing.

2.  **Dark Mode:**
    - A Dark Mode toggle has been added to the Options page.
    - You can now switch between light (default) and dark themes.
    - The chosen theme preference is saved and applied across both the Options page and the main Chat Popup.
    - The UI has been updated with a dark color palette, applied via CSS variables, ensuring readability and visual consistency in both modes.

These enhancements improve the user experience and provide more personalization options.