### PR TITLE
Refactor: Improve Confluence search logic with fallback

### DIFF
--- a/conrad_backend/app/services/confluence_service.py
+++ b/conrad_backend/app/services/confluence_service.py
@@ -1,7 +1,7 @@
+import logging
 from atlassian import Confluence
 from bs4 import BeautifulSoup
 from ..core.config import settings
-import logging
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -20,64 +20,12 @@ class ConfluenceService:
             logger.error(f"Failed to connect to Confluence: {e}")
             self.confluence = None
 
-    def search_content(self, search_terms: dict, space_keys: list[str] = None, limit: int = 5) -> list[dict]:
+    def _execute_cql_query(self, cql: str, limit: int) -> list[dict]:
         if not self.confluence:
-            logger.error("Confluence client not initialized. Cannot perform search.")
+            logger.error("Confluence client not initialized. Cannot execute CQL query.")
             return []
-
-        phrases = search_terms.get("phrases", []) # Expected to be 0-2 distinct phrases
-        keywords = search_terms.get("keywords", []) # Expected to be 0-5 distinct keywords
-
-        if not phrases and not keywords:
-            logger.warning("No search phrases or keywords provided.")
-            return []
-
-        cql_main_conditions = []
-
-        if phrases:
-            # If phrases are present, use them as the primary search condition.
-            # AND them together if multiple phrases for high precision.
-            phrase_cql_parts = []
-            for phrase in phrases:
-                escaped_phrase = phrase.replace('"', '\\"')
-                # Search in title OR text for the phrase
-                phrase_cql_parts.append(f'(title ~ "{escaped_phrase}" OR text ~ "{escaped_phrase}")')
-            if phrase_cql_parts:
-                cql_main_conditions.append(f"({' AND '.join(phrase_cql_parts)})")
-
-        # If no phrases were used for the main condition, or as an alternative broaden search (currently not alternative, but additive if also keywords)
-        # For now, if phrases are present, we rely on them. If not, we use keywords.
-        # If we want to combine, the logic would be: (PHRASES) AND (KEYWORDS_ORed) or (PHRASES) OR (KEYWORDS_ORed)
-        # Let's try: if phrases, use only phrases. If no phrases, use keywords.
-        # This simplifies the query significantly.
-
-        if not cql_main_conditions and keywords: # Only use keywords if no phrases were used
-            keyword_cql_parts = []
-            for keyword in keywords:
-                escaped_keyword = keyword.replace('"', '\\"')
-                # Search in title OR text for the keyword
-                keyword_cql_parts.append(f'(title ~ "{escaped_keyword}" OR text ~ "{escaped_keyword}")')
-            if keyword_cql_parts:
-                # OR keywords together to find documents containing any of them
-                cql_main_conditions.append(f"({' OR '.join(keyword_cql_parts)})")
-
-        if not cql_main_conditions:
-             logger.info("No valid search conditions from phrases or keywords.")
-             return [] # No terms to search for
-
-        # Now build the final query
-        cql_parts = [f"({cql_main_conditions[0]})"] # Main phrase/keyword condition
-
-        if space_keys and len(space_keys) > 0:
-            space_cql = " OR ".join([f'space = "{key.upper()}"' for key in space_keys])
-            cql_parts.append(f"({space_cql})")
-
-        cql_parts.append('type = "page"')
-        cql = " AND ".join(cql_parts)
-
-        logger.info(f"Simplified CQL for Confluence: {cql}")
-
         try:
+            logger.info(f"Executing Confluence CQL: {cql}")
             results = self.confluence.cql(cql, limit=limit, expand=None)
             if results and 'results' in results:
                 logger.info(f"Found {len(results['results'])} results.")
@@ -90,21 +38,112 @@ class ConfluenceService:
                     for result in results['results']
                 ]
             else:
-                logger.info("No results found or unexpected response format.")
+                logger.info("No results found or unexpected response format from CQL query.")
                 return []
         except Exception as e:
             logger.error(f"Error during Confluence search with CQL '{cql}': {e}")
-            # If it's a parse error, this log will show the problematic CQL.
             return []
 
+    def search_content(self, search_terms: dict, space_keys: list[str] = None, limit: int = 5) -> list[dict]:
+        if not self.confluence:
+            logger.error("Confluence client not initialized. Cannot perform search.")
+            return []
+
+        original_phrases = search_terms.get("phrases", [])
+        original_keywords = search_terms.get("keywords", [])
+
+        if not original_phrases and not original_keywords:
+            logger.warning("No search phrases or keywords provided.")
+            return []
+
+        # Common CQL parts
+        space_cql_part = ""
+        if space_keys and len(space_keys) > 0:
+            space_cql = " OR ".join([f'space = "{key.upper()}"' for key in space_keys])
+            space_cql_part = f"({space_cql})"
+
+        type_cql_part = 'type = "page"'
+
+        # Attempt 1: Phrase-based search (if phrases are provided)
+        if original_phrases:
+            phrase_cql_conditions = []
+            for phrase in original_phrases:
+                escaped_phrase = phrase.replace('"', '\\"') # Corrected escaping
+                phrase_cql_conditions.append(f'(title ~ "{escaped_phrase}" OR text ~ "{escaped_phrase}")')
+
+            if phrase_cql_conditions:
+                main_condition = f"({' AND '.join(phrase_cql_conditions)})"
+                cql_parts = [main_condition, type_cql_part]
+                if space_cql_part:
+                    cql_parts.insert(1, space_cql_part)
+                cql_attempt1 = " AND ".join(cql_parts)
+
+                results = self._execute_cql_query(cql_attempt1, limit)
+                if results:
+                    logger.info(f"Phrase search successful with {len(results)} results.")
+                    return results
+                else:
+                    logger.info("Phrase search yielded no results. Attempting fallback keyword search.")
+                    # Proceed to fallback keyword search logic below
+
+        # Fallback or Primary Keyword Search:
+        # This section is reached if:
+        # 1. original_phrases were provided but yielded no results (fallback).
+        # 2. No original_phrases were provided, so keywords are the primary search method.
+
+        effective_keywords = set()
+        # If falling back from phrases, derive keywords from them AND original keywords
+        if original_phrases:
+            for phrase in original_phrases:
+                effective_keywords.update(phrase.lower().split())
+            effective_keywords.update(k.lower() for k in original_keywords) # Add original keywords
+        else: # Primary keyword search (no phrases given initially)
+            effective_keywords.update(k.lower() for k in original_keywords)
+
+        if not effective_keywords:
+            logger.info("No effective keywords to search for after phrase fallback or initial check.")
+            return []
+
+        keyword_cql_conditions = []
+        for keyword in effective_keywords:
+            escaped_keyword = keyword.replace('"', '\\"') # Corrected escaping
+            keyword_cql_conditions.append(f'(title ~ "{escaped_keyword}" OR text ~ "{escaped_keyword}")')
+
+        if not keyword_cql_conditions:
+            logger.info("No valid keyword CQL conditions generated.")
+            return []
+
+        # If original_phrases were present (meaning this is a fallback), keywords should be ANDed.
+        # If no original_phrases, then this is a primary keyword search, use OR.
+        if original_phrases: # Fallback from phrases: AND keywords
+            main_condition = f"({' AND '.join(keyword_cql_conditions)})"
+        else: # Primary keyword search: OR keywords
+            main_condition = f"({' OR '.join(keyword_cql_conditions)})"
+
+        cql_parts = [main_condition, type_cql_part]
+        if space_cql_part:
+            cql_parts.insert(1, space_cql_part)
+        cql_attempt2 = " AND ".join(cql_parts)
+
+        results = self._execute_cql_query(cql_attempt2, limit)
+        if results:
+            logger.info(f"Keyword search successful with {len(results)} results.")
+        else:
+            logger.info("Keyword search also yielded no results.")
+        return results
+
     def get_page_content_by_id(self, page_id: str) -> str:
-        # ... (same as before)
-        if not self.confluence: return ""
+        if not self.confluence:
+            logger.error("Confluence client not initialized. Cannot get page content.")
+            return ""
         try:
             page = self.confluence.get_page_by_id(page_id, expand="body.storage")
             if page and "body" in page and "storage" in page["body"] and "value" in page["body"]["storage"]:
                 soup = BeautifulSoup(page["body"]["storage"]["value"], "html.parser")
+                # Using separator="\n" for BeautifulSoup's get_text
                 return soup.get_text(separator="\n", strip=True)
+            logger.warning(f"Page {page_id} found but no content in expected format.")
+            return ""
         except Exception as e:
             logger.error(f"Error fetching/parsing page {page_id}: {e}")
         return ""
@@ -116,36 +155,51 @@ if __name__ == "__main__":
     else:
         confluence_service = ConfluenceService()
         if confluence_service.confluence:
-            print("Testing ConfluenceService with simplified CQL logic...")
+            print("Testing ConfluenceService with new fallback CQL logic...")
 
-            # Test 1: Prioritize phrases (ANDed)
-            terms1 = {"phrases": ["alta de bridge", "proceso M2"], "keywords": ["configurar"]}
-            spaces1 = ["M2"]
-            print(f"\nTest 1: Terms: {terms1}, Spaces: {spaces1}")
-            results1 = confluence_service.search_content(search_terms=terms1, space_keys=spaces1)
+            # Test 1: Phrase search expected to work (or not, to test fallback)
+            terms1 = {"phrases": ["documentacion tecnica de desarollo"], "keywords": ["extra"]}
+            spaces1 = []
+            print(f"\nTest 1 (Phrase with Fallback): Terms: {terms1}, Spaces: {spaces1}")
+            results1 = confluence_service.search_content(search_terms=terms1, space_keys=spaces1, limit=3)
             if results1: print(f"Found {len(results1)} results for Test 1.")
             else: print("No results for Test 1.")
+            for res in results1: print(f"  - {res['title']}")
 
-            # Test 2: Only keywords (ORed)
-            terms2 = {"phrases": [], "keywords": ["salesforce", "beneficios", "manual"]}
-            print(f"\nTest 2: Terms: {terms2} (no spaces)")
-            results2 = confluence_service.search_content(search_terms=terms2)
+
+            # Test 2: Only keywords (ORed - existing behavior for this case)
+            terms2 = {"phrases": [], "keywords": ["salesforce", "manual"]}
+            print(f"\nTest 2 (Keywords ORed): Terms: {terms2}")
+            results2 = confluence_service.search_content(search_terms=terms2, limit=3)
             if results2: print(f"Found {len(results2)} results for Test 2.")
             else: print("No results for Test 2.")
+            for res in results2: print(f"  - {res['title']}")
 
-            # Test 3: Single phrase, no keywords
-            terms3 = {"phrases": ["como se edita un proceso"], "keywords": []}
-            print(f"\nTest 3: Terms: {terms3} (problematic query from user)")
-            results3 = confluence_service.search_content(search_terms=terms3)
+            # Test 3: Phrase that might exist
+            terms3 = {"phrases": ["alta de bridge"], "keywords": []}
+            spaces3 = ["M2"]
+            print(f"\nTest 3 (Specific Phrase): Terms: {terms3}, Spaces: {spaces3}")
+            results3 = confluence_service.search_content(search_terms=terms3, space_keys=spaces3, limit=3)
             if results3: print(f"Found {len(results3)} results for Test 3.")
             else: print("No results for Test 3.")
+            for res in results3: print(f"  - {res['title']}")
 
-            # Test 4: No phrases, few keywords, with space
+            # Test 4: No phrases, few keywords (ORed), with space
             terms4 = {"phrases": [], "keywords": ["edita", "proceso"]}
-            spaces4 = ["M2"] # Assuming M2 is a relevant space
-            print(f"\nTest 4: Terms: {terms4}, Spaces: {spaces4}")
-            results4 = confluence_service.search_content(search_terms=terms4, space_keys=spaces4)
+            spaces4 = ["M2"]
+            print(f"\nTest 4 (Keywords ORed with Space): Terms: {terms4}, Spaces: {spaces4}")
+            results4 = confluence_service.search_content(search_terms=terms4, space_keys=spaces4, limit=3)
             if results4: print(f"Found {len(results4)} results for Test 4.")
             else: print("No results for Test 4.")
+            for res in results4: print(f"  - {res['title']}")
+
+            # Test 5: A phrase that likely won't exist, to test fallback ANDing of its components
+            terms5 = {"phrases": ["nonexistent specific technical phrase"], "keywords": ["important"]}
+            print(f"\nTest 5 (Non-existent Phrase Fallback): Terms: {terms5}")
+            results5 = confluence_service.search_content(search_terms=terms5, limit=3)
+            if results5: print(f"Found {len(results5)} results for Test 5.")
+            else: print("No results for Test 5.")
+            for res in results5: print(f"  - {res['title']}")
+
         else:
             print("Could not initialize ConfluenceService.")


### PR DESCRIPTION
The Confluence search functionality in `confluence_service.py` has been updated to provide more robust and flexible search capabilities.

Previously, if your search query included phrases, the system would only search for those exact phrases. If no exact match was found, keywords would be ignored, often leading to no results for queries where the terms were present but not as an exact phrase.

The new logic introduces a fallback mechanism:
1. If phrases are provided, an exact phrase search (ANDing multiple phrases) is attempted first.
2. If the exact phrase search yields no results, the system now falls back to a keyword-based search. The keywords for this fallback are derived from the individual words of the input phrases, combined with any originally supplied keywords. This fallback search uses an AND logic for all effective keywords, requiring all terms to be present in the title or text.
3. If the initial query contains only keywords (no phrases), the system performs an ORed keyword search, maintaining the previous behavior for such cases.

A helper method `_execute_cql_query` was also introduced to streamline CQL execution and logging. Logging for CQL queries has been made more explicit to aid in debugging search behavior.

This change aims to improve recall for searches like "documentacion tecnica de desarollo" where the relevant page exists but does not contain the exact phrase, by allowing a broader (yet still relevant) keyword-based search as a fallback.