### PR TITLE
Add broad host permissions to manifest for diagnostics

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -58,8 +58,14 @@ function toggleSidebar() {
         sidebarIframe.style.display = 'block'; // Make it part of layout before transform
         // Force a reflow before applying the transform for the transition to work on first show
         void sidebarIframe.offsetHeight;
-        sidebarIframe.style.transform = 'translateX(0%)';
-        sidebarIframe.style.opacity = '1';
+
+        // Defer style changes that trigger transition to ensure display:block is processed
+        setTimeout(() => {
+            if (sidebarIframe) { // Ensure sidebarIframe still exists in this async callback
+                sidebarIframe.style.transform = 'translateX(0%)';
+                sidebarIframe.style.opacity = '1';
+            }
+        }, 10); // 10ms delay
     }
     isSidebarVisible = !isSidebarVisible;
     console.log("Conrad Sidebar: Visibility toggled. New state:", isSidebarVisible);

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
   "permissions": [
     "activeTab",
     "scripting",
-    "storage"
+    "storage",
+    "*://*/*"
   ],
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
I added "*://*/*" to the permissions array in manifest.json. This is a diagnostic step to investigate issues with content_script.js not loading on expected pages. This broad permission might help if the issue is related to subtle permission interpretation by the browser. Output: