### PR TITLE
Fix: Complete revert to popup extension baseline

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ body.popup-body {
   width: 350px; /* Reverted to popup width */ /* Default width for the popup */
   display: flex; /* Use flexbox for main layout */
   flex-direction: column; /* Stack chat container and input area vertically */
-  max-height: 600px; /* Increased for more vertical space */ /* Max height for the popup, helps with scroll */
+  max-height: 500px; /* Reverted to original popup max-height */ /* Max height for the popup, helps with scroll */
   overflow: hidden; /* Prevent body itself from scrolling */
 }
 
@@ -274,17 +274,14 @@ a:hover {
 /* Clarification Options Styling */
 #clarification-options-container {
   display: flex;
-  flex-wrap: wrap; /* Allow buttons to wrap */
-  justify-content: flex-start; /* Align to start */
-  /* align-items: flex-start; removed or keep if needed for single line */
+  flex-direction: column;
+  align-items: flex-start; /* Align buttons to the left like Conrad messages */
   margin-top: 10px;
   margin-bottom: 10px;
   gap: 8px; /* Adds space between option buttons */
 }
 
 .clarification-option {
-  flex-grow: 0;
-  flex-shrink: 0;
   background-color: var(--conrad-message-bg); /* Uses Conrad's background */
   color: var(--conrad-message-text);           /* Uses Conrad's text color */
   border: 1px solid var(--border-color);       /* Subtle border */


### PR DESCRIPTION
This commit finalizes the reversion of the extension to its standard popup functionality, undoing all sidebar-related changes. The goal is to provide a clean, working baseline before you attempt further UI modifications.

Changes included in this reversion process:
1.  **File Naming**: I ensured `popup.html` and `popup.js` are the definitive names, and any `sidebar.html` or `sidebar_script.js` files were removed or renamed.
2.  **HTML Link Correction**: I verified and corrected `popup.html` to link to `popup.js` and `style.css`.
3.  **Manifest Correction**: I cleaned `manifest.json` to only contain popup-specific configurations: `action.default_popup` set to `popup.html`, permissions set to `["storage"]`, and all sidebar-related keys (`background`, `content_scripts`, `web_accessible_resources`) removed.
4.  **Sidebar File Removal**: I ensured `background.js`, `content_script.js`, and `sidebar_container_styles.css` were removed.
5.  **CSS Reversion**: I reverted `style.css` to its original popup styling, including `body.popup-body` dimensions (`width: 350px`, `max-height: 500px`) and the original column layout for clarification option buttons.

I have reviewed all files to ensure they are in the correct state for a standard popup extension. This should resolve any `ERR_FILE_NOT_FOUND` issues you previously encountered due to the sidebar changes.